### PR TITLE
Add orientation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,15 @@ Default: `Math.floor(SCREEN_WIDTH / 8) * 8`
 
 ---
 
+### `orientation?: 'w' | 'b'`
+
+Sets which side should be displayed at the bottom of the board. `'w'` keeps the
+white pieces at the bottom while `'b'` flips the board so the black pieces are
+at the bottom. If omitted, the orientation follows the turn information from the
+`fen` string.
+
+---
+
 ### `renderPiece?: (piece: PieceType) => React.ReactElement | null`
 
 It gives the possibility to customise the chessboard pieces.

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -23,6 +23,7 @@ export default function App() {
       <StatusBar style="auto" />
       <Chessboard
         ref={ref}
+        orientation="b"
         onMove={({ state }) => {
           if (state.in_checkmate) {
             console.log('Life goes on.');

--- a/src/components/chessboard-background.tsx
+++ b/src/components/chessboard-background.tsx
@@ -29,7 +29,7 @@ interface SquareProps extends RowProps {
 
 const Square = React.memo(
   ({ white, row, col, letters, numbers }: SquareProps) => {
-    const { colors } = useChessboardProps();
+    const { colors, orientation } = useChessboardProps();
     const backgroundColor = white ? colors.black : colors.white;
     const color = white ? colors.white : colors.black;
     const textStyle = { fontWeight: '500' as const, fontSize: 10, color };
@@ -45,12 +45,14 @@ const Square = React.memo(
       >
         {numbers && (
           <Text style={[textStyle, { opacity: newLocal ? 1 : 0 }]}>
-            {'' + (8 - row)}
+            {orientation === 'w' ? 8 - row : row + 1}
           </Text>
         )}
-        {row === 7 && letters && (
-          <Text style={[textStyle, { alignSelf: 'flex-end' }]}>
-            {String.fromCharCode(97 + col)}
+        {(orientation === 'w' ? row === 7 : row === 0) && letters && (
+          <Text style={[textStyle, { alignSelf: 'flex-end' }]}> 
+            {orientation === 'w'
+              ? String.fromCharCode(97 + col)
+              : String.fromCharCode(97 + (7 - col))}
           </Text>
         )}
       </View>

--- a/src/components/highlighted-squares/index.tsx
+++ b/src/components/highlighted-squares/index.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { StyleSheet, View } from 'react-native';
+import type { Square } from 'chess.js';
 
 import { useChessboardProps } from '../../context/props-context/hooks';
 
@@ -12,7 +13,7 @@ const HighlightedSquares: React.FC = React.memo(() => {
   const chess = useChessEngine();
   const board = useMemo(() => chess.board(), [chess]);
   const { pieceSize } = useChessboardProps();
-  const { toPosition, toTranslation } = useReversePiecePosition();
+  const { toTranslation } = useReversePiecePosition();
   const refs = useSquareRefs();
 
   return (
@@ -23,7 +24,11 @@ const HighlightedSquares: React.FC = React.memo(() => {
     >
       {board.map((row, y) =>
         row.map((_, x) => {
-          const square = toPosition({ x: x * pieceSize, y: y * pieceSize });
+          const square = ((): Square => {
+            const col = String.fromCharCode(97 + x);
+            const rowIndex = 8 - y;
+            return `${col}${rowIndex}` as Square;
+          })();
           const translation = toTranslation(square);
 
           return (

--- a/src/components/pieces.tsx
+++ b/src/components/pieces.tsx
@@ -1,34 +1,39 @@
 import React from 'react';
+import type { Square } from 'chess.js';
 import { useChessboardProps } from '../context/props-context/hooks';
 
 import { useBoard } from '../context/board-context/hooks';
 import { usePieceRefs } from '../context/board-refs-context/hooks';
 
 import Piece from './piece';
-import { useReversePiecePosition } from '../notation';
 
 const Pieces = React.memo(() => {
   const board = useBoard();
   const refs = usePieceRefs();
-  const { pieceSize } = useChessboardProps();
-  const { toPosition } = useReversePiecePosition();
+  const { pieceSize, orientation } = useChessboardProps();
 
   return (
     <>
       {board.map((row, y) =>
         row.map((piece, x) => {
           if (piece !== null) {
-            const square = toPosition({
-              x: x * pieceSize,
-              y: y * pieceSize,
-            });
+            const square = ((): Square => {
+              const col = String.fromCharCode(97 + x);
+              const rowIndex = 8 - y;
+              return `${col}${rowIndex}` as Square;
+            })();
+
+            const displayPosition =
+              orientation === 'w'
+                ? { x, y }
+                : { x: 7 - x, y: 7 - y };
 
             return (
               <Piece
                 ref={refs?.current?.[square]}
                 key={`${x}-${y}`}
                 id={`${piece.color}${piece.type}` as const}
-                startPosition={{ x, y }}
+                startPosition={displayPosition}
                 square={square}
                 size={pieceSize}
               />

--- a/src/components/suggested-dots/PlaceholderDot.tsx
+++ b/src/components/suggested-dots/PlaceholderDot.tsx
@@ -21,9 +21,13 @@ type PlaceholderDotProps = {
 const PlaceholderDot: React.FC<PlaceholderDotProps> = React.memo(
   ({ x, y, selectableSquares, moveTo }) => {
     const { pieceSize } = useChessboardProps();
-    const { toPosition, toTranslation } = useReversePiecePosition();
+    const { toTranslation } = useReversePiecePosition();
 
-    const currentSquare = toPosition({ x: x * pieceSize, y: y * pieceSize });
+    const currentSquare = ((): Square => {
+      const col = String.fromCharCode(97 + x);
+      const rowIndex = 8 - y;
+      return `${col}${rowIndex}` as Square;
+    })();
     const translation = useMemo(
       () => toTranslation(currentSquare),
       [currentSquare, toTranslation]

--- a/src/context/props-context/index.tsx
+++ b/src/context/props-context/index.tsx
@@ -62,13 +62,19 @@ type ChessboardProps = {
    * Useful if you want to customise the default durations used in the chessboard (in milliseconds).
    */
   durations?: ChessboardDurationsType;
+  /**
+   * Defines which side should be at the bottom of the board.
+   * Possible values are 'w' (white) or 'b' (black).
+   * By default it will follow the turn from the provided fen string.
+   */
+  orientation?: 'w' | 'b';
 };
 
 type ChessboardContextType = ChessboardProps &
   Required<
     Pick<
       ChessboardProps,
-      'gestureEnabled' | 'withLetters' | 'withNumbers' | 'boardSize'
+      'gestureEnabled' | 'withLetters' | 'withNumbers' | 'boardSize' | 'orientation'
     >
   > & { pieceSize: number } & {
     colors: Required<ChessboardColorsType>;
@@ -94,6 +100,7 @@ const defaultChessboardProps: ChessboardContextType = {
   withNumbers: true,
   boardSize: DEFAULT_BOARD_SIZE,
   pieceSize: DEFAULT_BOARD_SIZE / 8,
+  orientation: 'w',
 };
 
 const ChessboardPropsContext = React.createContext<ChessboardContextType>(
@@ -103,9 +110,12 @@ const ChessboardPropsContext = React.createContext<ChessboardContextType>(
 const ChessboardPropsContextProvider: React.FC<ChessboardProps> = React.memo(
   ({ children, ...rest }) => {
     const value = useMemo(() => {
+      const orientationFromFen =
+        rest.fen?.split(' ')[1] === 'b' ? 'b' : 'w';
       const data = {
         ...defaultChessboardProps,
         ...rest,
+        orientation: rest.orientation ?? orientationFromFen,
         colors: { ...defaultChessboardProps.colors, ...rest.colors },
         durations: { ...defaultChessboardProps.durations, ...rest.durations },
       };

--- a/src/notation.ts
+++ b/src/notation.ts
@@ -5,7 +5,7 @@ import { useChessboardProps } from './context/props-context/hooks';
 import type { Vector } from './types';
 
 const useReversePiecePosition = () => {
-  const { pieceSize } = useChessboardProps();
+  const { pieceSize, orientation } = useChessboardProps();
 
   const toTranslation = useCallback(
     (to: Square) => {
@@ -20,22 +20,34 @@ const useReversePiecePosition = () => {
         x: col.charCodeAt(0) - 'a'.charCodeAt(0),
         y: parseInt(row, 10) - 1,
       };
+      if (orientation === 'w') {
+        return {
+          x: indexes.x * pieceSize,
+          y: 7 * pieceSize - indexes.y * pieceSize,
+        };
+      }
       return {
-        x: indexes.x * pieceSize,
-        y: 7 * pieceSize - indexes.y * pieceSize,
+        x: (7 - indexes.x) * pieceSize,
+        y: indexes.y * pieceSize,
       };
     },
-    [pieceSize]
+    [pieceSize, orientation]
   );
 
   const toPosition = useCallback(
     ({ x, y }: Vector) => {
       'worklet';
-      const col = String.fromCharCode(97 + Math.round(x / pieceSize));
-      const row = `${8 - Math.round(y / pieceSize)}`;
+      const colIndex = orientation === 'w'
+        ? Math.round(x / pieceSize)
+        : 7 - Math.round(x / pieceSize);
+      const rowIndex = orientation === 'w'
+        ? 7 - Math.round(y / pieceSize)
+        : Math.round(y / pieceSize);
+      const col = String.fromCharCode(97 + colIndex);
+      const row = `${rowIndex + 1}`;
       return `${col}${row}` as Square;
     },
-    [pieceSize]
+    [pieceSize, orientation]
   );
 
   return { toPosition, toTranslation };


### PR DESCRIPTION
## Summary
- allow passing `orientation` prop to control which side is at the bottom
- compute orientation from FEN when prop not given
- adjust translation helpers and board rendering for orientation
- document new prop and show usage in example